### PR TITLE
Move worker into a separate process group

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,6 @@
+[build]
+rustflags = ["--cfg", "tokio_unstable"]
+
 [target.i686-unknown-linux-musl]
 linker = "rust-lld"
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -110,13 +110,15 @@ impl Cli {
 async fn spawn_worker_and_wait_for_ok() -> anyhow::Result<()> {
     let mut remaining = env::args_os();
     let program = remaining.next().expect("arg0");
-    let mut worker = Command::new(program)
-        .arg("--worker")
-        .args(remaining)
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::inherit())
-        .spawn()?;
+    let mut command = Command::new(program);
+    command.arg("--worker");
+    command.args(remaining);
+    command.stdin(Stdio::null());
+    command.stdout(Stdio::piped());
+    command.stderr(Stdio::inherit());
+    #[cfg(unix)]
+    command.process_group(0);
+    let mut worker = command.spawn()?;
     let worker_pid = worker.id().expect("child pid");
     println!("{worker_pid}"); // to allow MY_VM=$(fleeting ... --bg) for later killing
     let mut stdout = worker.stdout.take().expect("stdout");


### PR DESCRIPTION
... to prevent ctrl-c on a subsequent command from terminating it.